### PR TITLE
add cloudrun scripts

### DIFF
--- a/cloudrun/.dockerignore
+++ b/cloudrun/.dockerignore
@@ -1,0 +1,7 @@
+Dockerfile
+README.md
+*.pyc
+*.pyo
+*.pyd
+__pycache__
+.pytest_cache

--- a/cloudrun/Dockerfile
+++ b/cloudrun/Dockerfile
@@ -1,0 +1,27 @@
+# Use the official lightweight Python image.
+# https://hub.docker.com/_/python
+FROM python:3.9
+
+# Allow statements and log messages to immediately appear in the Knative logs
+ENV PYTHONUNBUFFERED True
+
+# Copy local code to the container image.
+ENV APP_HOME /app
+WORKDIR $APP_HOME
+COPY requirements.txt ./
+
+# Install production dependencies.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends gcc \
+  && rm -rf /var/lib/apt/lists/* \
+  && CFLAGS='-stdlib=libc++' \
+  && pip install -r requirements.txt \
+  && apt-get purge -y --auto-remove gcc
+
+COPY . ./
+# Run the web service on container startup. Here we use the gunicorn
+# webserver, with one worker process and 8 threads.
+# For environments with multiple CPU cores, increase the number of workers
+# to be equal to the cores available.
+# Timeout is set to 0 to disable the timeouts of the workers to allow Cloud Run to handle instance scaling.
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app

--- a/cloudrun/main.py
+++ b/cloudrun/main.py
@@ -1,0 +1,30 @@
+import os
+from flask import Flask, request
+import pkg_resources, imp
+imp.reload(pkg_resources)
+
+import spacy
+nlp = spacy.load('ja_ginza')
+
+app = Flask(__name__)
+
+@app.route("/nouns", methods=['POST'])
+def extract_nouns():
+    request_json = request.get_json()
+    if request_json and 'title' in request_json:
+
+        title = request_json['title']
+        doc = nlp(title)
+
+        nouns = []
+        for sent in doc.sents:
+            nouns += [token.orth_ for token in sent if "NOUN" in token.pos_]
+                
+        return { "nouns": ",".join(nouns) }
+
+    else:
+        return { "msg": "params are not exits" }
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 8080)))

--- a/cloudrun/requirements.txt
+++ b/cloudrun/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+gunicorn
+ginza


### PR DESCRIPTION
形態素解析について，jsのtinysegmenterでは心許なく，janomeも心許なく，pip一発で導入できるginzaをcloud functionで利用しようとしたが，sudachidict関係でこけるのではcloud runを採用

重要語抽出はよく考えたら不要な気がしたのと，集合の簡単な類似度であればフロントでできるのでとりあえず名詞抽出のみ